### PR TITLE
fix: Fix for Realtime Functionality in Supabase-on-AWS Description

### DIFF
--- a/containers/kong/kong-template.yml
+++ b/containers/kong/kong-template.yml
@@ -136,7 +136,7 @@ services:
   ## Secure Realtime routes
   - name: realtime-v1
     _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
-    url: ${SUPABASE_REALTIME_URL:=http://realtime:4000/socket/}
+    url: ${SUPABASE_REALTIME_SOCKET_URL:=http://realtime:4000/socket/}
     routes:
       - name: realtime-v1-all
         strip_path: true
@@ -153,6 +153,27 @@ services:
           allow:
             - admin
             - anon
+
+  # For Realtime-API routes
+  - name: realtime-v1-api
+    _comment: 'Realtime: /realtime/v1/api/* -> ws://realtime:4000/api/*'
+    url: ${SUPABASE_REALTIME_API_URL:=http://realtime:4000/api/}
+    routes:
+      - name: realtime-v1-api-routes
+        paths:
+          - /realtime/v1/api
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+          
 
   ## Storage routes: the storage server manages its own auth
   - name: storage-v1

--- a/src/supabase-stack.ts
+++ b/src/supabase-stack.ts
@@ -106,7 +106,7 @@ export class SupabaseStack extends FargateStack {
     });
     const realtimeImageUri = new cdk.CfnParameter(this, 'RealtimeImageUri', {
       type: 'String',
-      default: 'public.ecr.aws/supabase/realtime:v2.25.27',
+      default: 'public.ecr.aws/supabase/realtime:v2.25.60',
       description: 'https://gallery.ecr.aws/supabase/realtime',
     });
     const storageImageUri = new cdk.CfnParameter(this, 'StorageImageUri', {

--- a/src/supabase-stack.ts
+++ b/src/supabase-stack.ts
@@ -96,22 +96,22 @@ export class SupabaseStack extends FargateStack {
 
     const authImageUri = new cdk.CfnParameter(this, 'AuthImageUri', {
       type: 'String',
-      default: 'public.ecr.aws/supabase/gotrue:v2.110.0',
+      default: 'public.ecr.aws/supabase/gotrue:v2.139.1',
       description: 'https://gallery.ecr.aws/supabase/gotrue',
     });
     const restImageUri = new cdk.CfnParameter(this, 'RestImageUri', {
       type: 'String',
-      default: 'public.ecr.aws/supabase/postgrest:v11.2.0',
+      default: 'public.ecr.aws/supabase/postgrest:v12.0.2',
       description: 'https://gallery.ecr.aws/supabase/postgrest',
     });
     const realtimeImageUri = new cdk.CfnParameter(this, 'RealtimeImageUri', {
       type: 'String',
-      default: 'public.ecr.aws/supabase/realtime:v2.25.60',
+      default: 'public.ecr.aws/supabase/realtime:v2.25.61',
       description: 'https://gallery.ecr.aws/supabase/realtime',
     });
     const storageImageUri = new cdk.CfnParameter(this, 'StorageImageUri', {
       type: 'String',
-      default: 'public.ecr.aws/supabase/storage-api:v0.43.11',
+      default: 'public.ecr.aws/supabase/storage-api:v0.46.5',
       description: 'https://gallery.ecr.aws/supabase/storage-api',
     });
     const imgproxyImageUri = new cdk.CfnParameter(this, 'ImgproxyImageUri', {
@@ -121,7 +121,7 @@ export class SupabaseStack extends FargateStack {
     });
     const postgresMetaImageUri = new cdk.CfnParameter(this, 'PostgresMetaImageUri', {
       type: 'String',
-      default: 'public.ecr.aws/supabase/postgres-meta:v0.74.2',
+      default: 'public.ecr.aws/supabase/postgres-meta:v0.75.0',
       description: 'https://gallery.ecr.aws/supabase/postgres-meta',
     });
 
@@ -284,7 +284,8 @@ export class SupabaseStack extends FargateStack {
     const kong = new AutoScalingFargateService(this, 'Kong', {
       cluster,
       taskImageOptions: {
-        image: ecs.ContainerImage.fromRegistry('public.ecr.aws/u3p7q2r8/kong:latest'),
+        // image: ecs.ContainerImage.fromRegistry('public.ecr.aws/u3p7q2r8/kong:latest'),
+        image: ecs.ContainerImage.fromRegistry('public.ecr.aws/k1e4k0b3/kong:latest'), // FIX: new kong-template.yml version
         //image: ecs.ContainerImage.fromAsset('./containers/kong', { platform: Platform.LINUX_ARM64 }),
         containerPort: 8000,
         healthCheck: {
@@ -592,7 +593,8 @@ export class SupabaseStack extends FargateStack {
     kong.service.taskDefinition.defaultContainer!.addEnvironment('SUPABASE_AUTH_URL', `${auth.endpoint}/`);
     kong.service.taskDefinition.defaultContainer!.addEnvironment('SUPABASE_REST_URL', `${rest.endpoint}/`);
     //kong.service.taskDefinition.defaultContainer!.addEnvironment('SUPABASE_GRAPHQL_URL', `${gql.endpoint}/graphql`);
-    kong.service.taskDefinition.defaultContainer!.addEnvironment('SUPABASE_REALTIME_URL', `${realtime.endpoint}/socket/`);
+    kong.service.taskDefinition.defaultContainer!.addEnvironment('SUPABASE_REALTIME_SOCKET_URL', `${realtime.endpoint}/socket/`);
+    kong.service.taskDefinition.defaultContainer!.addEnvironment('SUPABASE_REALTIME_API_URL', `${realtime.endpoint}/api/`);    
     kong.service.taskDefinition.defaultContainer!.addEnvironment('SUPABASE_STORAGE_URL', `${storage.endpoint}/`);
     kong.service.taskDefinition.defaultContainer!.addEnvironment('SUPABASE_META_HOST', `${meta.endpoint}/`);
 


### PR DESCRIPTION
While implementing supabase-on-aws, I encountered an issue where the realtime functionality was not working as expected. After investigating, I found a similar issue reported on the Supabase Realtime GitHub repository https://github.com/supabase/realtime/issues/372, which led me to a solution.

Changes Made
Updated Realtime Version in Supabase Stack
I updated the Docker image version for the Supabase Realtime service in src/supabase-stack.ts to resolve the initial issue with the Realtime service not functioning properly.

```
Before: public.ecr.aws/supabase/realtime:v2.25.27
After: public.ecr.aws/supabase/realtime:v2.25.60
```
This change allowed the following code to work, enabling successful subscription and message broadcast between clients:

```javascript

    // client1.ts
    const channelA = supabase.channel('room')

    channelA
    .on(
      'broadcast',
      { event: '*' },
      (payload :any ) => messageReceived(payload)
    )
    .subscribe((status :any ) => {
        console.log("log -> ~ .subscribe ~ status:", status)
    })

    // client2.ts
    const channelA = supabase.channel('room')

    channelA.subscribe((status) => {
        if (status !== 'SUBSCRIBED') { return }
        channelA.send({
        type: 'broadcast',
        event: 'test',
        payload: { message: 'talking to myself' },
        })
    })

```
Identified Issue with API-based Messaging
However, I noticed that sending messages via the API instead of directly through WebSockets did not work. This issue was discussed in a Supabase community discussion https://github.com/orgs/supabase/discussions/18790#discussioncomment-7580134.

Configuration Adjustments in Kong Template
To address this, I made adjustments in the containers/kong/kong-template.yml to properly route Realtime and Realtime-API requests, and updated environment variables in src/supabase-stack.ts for consistency.

Updated SUPABASE_REALTIME_URL to SUPABASE_REALTIME_SOCKET_URL and added SUPABASE_REALTIME_API_URL.
Updated the Kong Docker image to a newer version with a revised kong-template.yml.


// containers/kong/kong-template.yml
```yml
  ## Secure Realtime routes
  - name: realtime-v1
    _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
    url: ${SUPABASE_REALTIME_SOCKET_URL:=http://realtime:4000/socket/}
    routes:
      - name: realtime-v1-all
        strip_path: true
        paths:
          - /realtime/v1/
    plugins:
      - name: cors
      - name: key-auth
        config:
          hide_credentials: false
      - name: acl
        config:
          hide_groups_header: true
          allow:
            - admin
            - anon

  # For Realtime-API routes
  - name: realtime-v1-api
    _comment: 'Realtime: /realtime/v1/api/* -> ws://realtime:4000/api/*'
    url: ${SUPABASE_REALTIME_API_URL:=http://realtime:4000/api/}
    routes:
      - name: realtime-v1-api-routes
        paths:
          - /realtime/v1/api
    plugins:
      - name: cors
      - name: key-auth
        config:
          hide_credentials: false
      - name: acl
        config:
          hide_groups_header: true
          allow:
            - admin
            - anon
          
```

//  src/supabase-stack.ts

```javascript

- kong.service.taskDefinition.defaultContainer!.addEnvironment('SUPABASE_REALTIME_URL', `${realtime.endpoint}/socket/`);
+ kong.service.taskDefinition.defaultContainer!.addEnvironment('SUPABASE_REALTIME_SOCKET_URL', `${realtime.endpoint}/socket/`);
+ kong.service.taskDefinition.defaultContainer!.addEnvironment('SUPABASE_REALTIME_API_URL', `${realtime.endpoint}/api/`);

-  image: ecs.ContainerImage.fromRegistry('public.ecr.aws/u3p7q2r8/kong:latest'),
+ image: ecs.ContainerImage.fromRegistry('public.ecr.aws/k1e4k0b3/kong:latest'), // FIX: new kong-template.yml version
```

Final Outcome
After making these changes, both WebSocket-based and API-based messaging functionalities were working as expected, resolving the initial issue with the Realtime service.

// Example of client code with successful Realtime functionality
```javascript

    // client1.ts
    const channelA = supabase.channel('room')

    channelA
    .on(
      'broadcast',
      { event: '*' },
      (payload :any ) => messageReceived(payload)
    )
    .subscribe((status :any ) => {
        console.log("log -> ~ .subscribe ~ status:", status)
    })

    // client2.ts
    const channelA = supabase.channel('room')
    // not subscribe
    const data = await channelA
        .send({
        type: 'broadcast',
        event: 'test',
        payload: { message: 'hi~' },
        },{

        })

```

Conclusion
I hope this pull request will be merged to help others facing similar issues with Realtime functionality in Supabase-on-AWS. This solution has been tested and confirmed to work, providing a path forward for those experiencing similar challenges.