### PR TITLE
fix: Change IAM Policy JSON so AWS IAM Console does not complain about format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ This repo includes a template of starting Supabase stack on AWS via CloudFormati
                 "ssm:*",
                 "states:*",
                 "rds:*",
-                "route53:*",
+                "route53:*"
             ],
             "Resource": "*"
         },
         {
-            "Sid": "supabase-cdn",
+            "Sid": "supabaseCdn",
             "Effect": "Allow",
             "Action": [
                 "cloudfront:*",
@@ -134,18 +134,18 @@ This repo includes a template of starting Supabase stack on AWS via CloudFormati
             "Resource": "*"
         },
         {
-            "Sid": "cache-manager",
+            "Sid": "cacheManager",
             "Effect": "Allow",
             "Action": [
                 "apigateway:*",
                 "lambda:*",
                 "logs:*",
-                "sqs:*",
+                "sqs:*"
             ],
             "Resource": "*"
         },
         {
-            "Sid": "supabase-studio",
+            "Sid": "supabaseStudio",
             "Effect": "Allow",
             "Action": [
                 "amplify:*",


### PR DESCRIPTION
The JSON file that contains the IAM roles supplied in the README makes the AWS IAM console complain about formatting. This PR fixes those problems by:
- Removing traling commas
- Removing hyphens from the "Sid" fields